### PR TITLE
[Api] Increase rate limit

### DIFF
--- a/attendance-api/app/Providers/RouteServiceProvider.php
+++ b/attendance-api/app/Providers/RouteServiceProvider.php
@@ -66,7 +66,7 @@ class RouteServiceProvider extends ServiceProvider
     protected function configureRateLimiting()
     {
         RateLimiter::for('api', function (Request $request) {
-            return Limit::perMinute(60)->by(optional($request->user())->id ?: $request->ip());
+            return Limit::perMinute(180)->by(optional($request->user())->id ?: $request->ip());
         });
     }
 }


### PR DESCRIPTION
Previously, the app would limit requests to a maximum of 60/s/user. However, with a polling interval of 1s on the main screen, we could hit this very quickly (especially since polling performs 2 individual requests).

This increases the rate limit to 180 requests/s/user.

Fixes #39 (hopefully)