### PR TITLE
Consider timezones in meeting report

### DIFF
--- a/attendance-api/config/config.php
+++ b/attendance-api/config/config.php
@@ -1,5 +1,6 @@
 <?php
 
 return [
-    'simultaneous_interval' => 60
+    'simultaneous_interval' => 60,
+    'default_client_timezone' => '-08:00'
 ];

--- a/attendance-web/src/app/components/reports/meetings-report/meetings-report.component.ts
+++ b/attendance-web/src/app/components/reports/meetings-report/meetings-report.component.ts
@@ -56,7 +56,6 @@ export class MeetingsReportComponent {
       dates: this.selectedInterval,
       stats: this.meetingData
     }).subscribe(({dates, stats}) => {
-      const statsByDate = new Map(stats.map(it => [it.meeting_date.toMillis(), it]));
       const data = {
         datasets: [{
           label: 'Student Count',


### PR DESCRIPTION
Meeting attendance is determined by grouping attendance sessions by date and counting the number of unique students.

```sql
SELECT
    CAST(checkin_date AS DATE) AS meeting_date,
    COUNT(DISTINCT student_id) AS student_count
FROM attendance_events
GROUP BY meeeting_date;
```

However, grouping by day is very dependent on timezone, as two events that occurred on the same day in one timezone may have occurred on different days from the perspective of a different timezone. Since our meetings occur in the PTC/`-08:00` timezone, but dates are stored in the database in `UTC`, this was causing meeting attendance to be "smeared" across 2 days (since check-ins that happened before 16:00 PST/0:00 UTC "counted" towards a different day from check-ins that happened on or after 16:00 PST/0:00 UTC).

The solution is to take the client's timezone as an argument (with an configurable default of PST/`-08:00`), then convert the `UTC` dates into the client's timezone before grouping.

```sql
SELECT
    CAST(CONVERT_TZ(checkin_date, "UTC", ?) AS DATE) AS meeting_date,
    COUNT(DISTINCT student_id) AS student_count
FROM attendance_events
GROUP BY meeeting_date;
```

_(I really, **really** hate timezones)_