### PR TITLE
Redesign attendance events and polling endpoint

### DIFF
--- a/attendance-api/app/Console/Commands/EndMeeting.php
+++ b/attendance-api/app/Console/Commands/EndMeeting.php
@@ -39,6 +39,7 @@ class EndMeeting extends Command
                 (
                     SELECT MAX(created_at) as latest_date, student_id
                     FROM attendance_events
+                    WHERE deleted_at IS NULL
                     GROUP BY student_id
                     HAVING latest_date > (
                         SELECT MAX(created_at) as latest_eom
@@ -48,6 +49,7 @@ class EndMeeting extends Command
                 ) AS latest_table
                 ON attendance_events.student_id = latest_table.student_id
                 AND attendance_events.created_at = latest_table.latest_date
+                WHERE attendance_events.deleted_at IS NULL
             ) AS events
             ON students.id = events.student_id
             WHERE `type` = 'check-in';

--- a/attendance-api/app/Console/Commands/ValidateAttendanceEvents.php
+++ b/attendance-api/app/Console/Commands/ValidateAttendanceEvents.php
@@ -63,9 +63,11 @@ class ValidateAttendanceEvents extends Command
             AND e2.created_at = (
                 SELECT MAX(created_at)
                 FROM attendance_events
-                WHERE student_id = e.student_id AND created_at < e.created_at
+                WHERE student_id = e.student_id
+                    AND created_at < e.created_at
+                    AND deleted_at IS NULL
             )
-            WHERE e.type = 'check-out' AND e2.type = 'check-out'
+            WHERE e.deleted_at IS NULL AND e.type = 'check-out' AND e2.type = 'check-out'
             EOF;
         return collect(DB::select($query))->pluck('id');
     }
@@ -88,9 +90,9 @@ class ValidateAttendanceEvents extends Command
             AND e2.created_at = (
                 SELECT MAX(created_at)
                 FROM attendance_events
-                WHERE student_id = e.student_id AND created_at < e.created_at
+                WHERE deleted_at IS NULL AND student_id = e.student_id AND created_at < e.created_at
             )
-            WHERE TIMESTAMPDIFF(SECOND, e2.created_at, e.created_at) <= ?;
+            WHERE e.deleted_at IS NULL AND e2.deleted_at IS NULL AND TIMESTAMPDIFF(SECOND, e2.created_at, e.created_at) <= ?;
             EOF;
 
         $events = collect(DB::select($query, [$simultaneous_interval]));

--- a/attendance-api/app/Http/Controllers/AttendanceEventController.php
+++ b/attendance-api/app/Http/Controllers/AttendanceEventController.php
@@ -70,29 +70,28 @@ class AttendanceEventController extends Controller
 
         $student = Student::find($request->student_id);
 
-        $last_event = $student->attendanceEvents()->orderBy('created_at', 'desc')->first();
-        if(Carbon::now()->diffInSeconds($last_event->created_at) < config('config.simultaneous_interval')) {
-            if($request->type == $last_event->type) {
-                throw ValidationException::withMessages([
-                    'student_id' => ['A recent '.$request->type.' already exists for this student.']
-                ]);
-            }
-
-            // TODO: If two events have different type, the previous event is removed and the new
-            //       event is ignored as the new event is likely an attempt to "undo" the old event.
-            //
-            //       Since this involves deleting attendance records, we cannot implement it until
-            //       there is some mechanism in-place to notify polling clients that an event has
-            //       been deleted. This will need to wait until we have implemented the server-side
-            //       undo that is discussed in #40.
-        }
-
         $event = new AttendanceEvent;
         $event->type = $request->type;
         $event->registered_by = Auth::id();
 
-        $student->attendanceEvents()->save($event);
+        $last_event = $student->attendanceEvents()->orderBy('created_at', 'desc')->first();
+        if($last_event != null && Carbon::now()->diffInSeconds($last_event->created_at) < config('config.simultaneous_interval')) {
+            if($request->type == $last_event->type) {
+                throw ValidationException::withMessages([
+                    'student_id' => ['A recent '.$request->type.' already exists for this student.']
+                ]);
+            } else {
+                // If two events have different type, the new event is saved, but both the previous
+                // and current events are soft-deleted, since the new event is likely an attempt
+                // to "undo" the old event
+                $last_event->delete();
+                $student->attendanceEvents()->save($event)->delete();
 
+                return $event;
+            }
+        }
+
+        $student->attendanceEvents()->save($event);
         return $event;
     }
 

--- a/attendance-api/app/Http/Controllers/AttendanceEventController.php
+++ b/attendance-api/app/Http/Controllers/AttendanceEventController.php
@@ -101,4 +101,14 @@ class AttendanceEventController extends Controller
         return $event;
     }
 
+    public function destroy(AttendanceEvent $event) {
+        if(Carbon::now()->diffInSeconds($event->created_at) > config('config.undo_window')) {
+            throw ValidationException::withMessages([
+                'id' => ['The record cannot be removed as the undo window has elapsed.']
+            ]);
+        }
+
+        $event->delete();
+    }
+
 }

--- a/attendance-api/app/Http/Controllers/PollController.php
+++ b/attendance-api/app/Http/Controllers/PollController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+use Carbon\Carbon;
+
+use App\Models\AttendanceEvent;
+use App\Models\MeetingEvent;
+use App\Models\Student;
+
+class PollController extends Controller
+{
+    public function poll(Request $request) {
+        $request->validate([
+            'since' => 'date_format:U|lt:4294967295|required',
+            'until' => 'date_format:U|lt:4294967295'
+        ]);
+
+        $since_dt = Carbon::createFromTimestamp($request->since);
+        $until_dt = null;
+        if($request->has('until')) {
+            $until_dt = Carbon::createFromTimestamp($request->until);
+        }
+
+        $query = AttendanceEvent::withTrashed()->where('created_at', '>=', $since_dt);
+        if($until_dt != null) {
+            $query->where('created_at', '<=',  $until_dt);
+        }
+
+        $query->orWhere(function($query) use ($since_dt, $until_dt) {
+            $query->where('deleted_at', '>=', $since_dt);
+            if($until_dt != null) {
+                $query->where('deleted_at', '<=',  $until_dt);
+            }
+        });
+
+        $updated_events = $query->get();
+        $updated_students = Student::findMany($updated_events->pluck('student_id')->unique());
+
+        $query = MeetingEvent::where('created_at', '>=', $since_dt);
+        if($until_dt != null) {
+            $query = $query->where('created_at', '<=', $until_dt);
+        }
+        $meeting_events = $query->get();
+
+        return [
+            'updated_students' => $updated_students,
+            'meeting_events' => $meeting_events
+        ];
+    }
+}

--- a/attendance-api/app/Models/AttendanceEvent.php
+++ b/attendance-api/app/Models/AttendanceEvent.php
@@ -3,11 +3,13 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Model;
 
 class AttendanceEvent extends Model
 {
     use HasFactory;
+    use SoftDeletes;
 
     protected $casts = [
         'student_id' => 'integer',

--- a/attendance-api/config/config.php
+++ b/attendance-api/config/config.php
@@ -2,5 +2,6 @@
 
 return [
     'simultaneous_interval' => 60,
-    'default_client_timezone' => '-08:00'
+    'default_client_timezone' => '-08:00',
+    'undo_window' => 30
 ];

--- a/attendance-api/database/migrations/2023_04_13_203625_soft_delete_attendance_events.php
+++ b/attendance-api/database/migrations/2023_04_13_203625_soft_delete_attendance_events.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class SoftDeleteAttendanceEvents extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('attendance_events', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('attendance_events', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+}

--- a/attendance-api/database/migrations/2023_04_13_231136_update_attendance_sesions_view_for_soft_deletes.php
+++ b/attendance-api/database/migrations/2023_04_13_231136_update_attendance_sesions_view_for_soft_deletes.php
@@ -2,9 +2,9 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
-class CreateAttendanceSessionsTable extends Migration
+class UpdateAttendanceSesionsViewForSoftDeletes extends Migration
 {
     /**
      * Run the migrations.
@@ -26,14 +26,16 @@ class CreateAttendanceSessionsTable extends Migration
                     SELECT IF(type = 'check-out', id, NULL) FROM attendance_events AS check_out_id_subquery
                     WHERE check_out_id_subquery.student_id = check_in.student_id
                         AND check_out_id_subquery.created_at > check_in.created_at
+                        AND check_out_id_subquery.deleted_at IS NULL
                     ORDER BY check_out_id_subquery.created_at ASC
                     LIMIT 1
                 ) AS checkout_id
                 FROM attendance_events AS check_in
-                WHERE type = 'check-in'
+                WHERE type = 'check-in' AND deleted_at IS NULL
             ) AS check_in
             LEFT JOIN attendance_events AS check_out
                 ON check_in.checkout_id = check_out.id
+            WHERE check_out.deleted_at IS NULL
             ORDER BY student_id ASC, checkin_date DESC;
             EOD;
         DB::statement($query);

--- a/attendance-api/routes/api.php
+++ b/attendance-api/routes/api.php
@@ -25,7 +25,7 @@ use Spatie\Permission\Models\Role;
 Route::middleware('auth:sanctum')->group(function () {
     Route::apiResource('students', StudentController::class);
     Route::apiResource('attendance/events', AttendanceEventController::class)->only([
-        'index', 'show', 'store'
+        'index', 'show', 'store', 'destroy'
     ]);
 
     Route::apiResource('attendance/sessions', AttendanceSessionController::class)->only([

--- a/attendance-api/routes/api.php
+++ b/attendance-api/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\AttendanceSessionController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\MeetingEventController;
 use App\Http\Controllers\StatsController;
+use App\Http\Controllers\PollController;
 
 use Spatie\Permission\Models\Role;
 
@@ -49,6 +50,7 @@ Route::middleware('auth:sanctum')->group(function () {
     });
 
     Route::get('stats/meetings', [StatsController::class, 'meetings']);
+    Route::get('poll', [PollController::class, 'poll']);
 });
 
 

--- a/attendance-web/src/app/app.component.ts
+++ b/attendance-web/src/app/app.component.ts
@@ -26,10 +26,4 @@ export class AppComponent {
       user?.name.split(" ")[0] ?? null
     ));
   }
-
-  @HostListener('window:beforeunload')
-  noPendingChanges(): boolean {
-    this.snackbar.dismiss();
-    return !this.studentsService.isUpdatePending();
-  }
 }

--- a/attendance-web/src/app/components/add-attendance-event-list/add-attendance-event-list.component.ts
+++ b/attendance-web/src/app/components/add-attendance-event-list/add-attendance-event-list.component.ts
@@ -141,29 +141,6 @@ export class AddAttendanceEventListComponent implements OnInit, AfterViewInit, O
         return;
       }
 
-      let now = DateTime.now()
-      let dummyEvent : AttendanceEvent = {
-        id: -1,
-        student_id: student.id,
-        registered_by: user.id,
-        type: action,
-        created_at: now,
-        updated_at: now
-      };
-
-      let updatedStudent = {
-        ...student
-      };
-
-      switch(action){
-        case AttendanceEventType.CHECK_IN:
-          updatedStudent.last_check_in = dummyEvent;
-          break;
-        case AttendanceEventType.CHECK_OUT:
-          updatedStudent.last_check_out = dummyEvent;
-          break;
-      };
-
         const eventStr = {
           [AttendanceEventType.CHECK_IN]: "checked in",
           [AttendanceEventType.CHECK_OUT]: "checked out"

--- a/attendance-web/src/app/components/students/show-student/show-student.component.ts
+++ b/attendance-web/src/app/components/students/show-student/show-student.component.ts
@@ -3,7 +3,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { DateTime } from 'luxon';
-import { AsyncSubject, BehaviorSubject, catchError, combineLatest, filter, map, Observable, of, ReplaySubject, share, startWith, switchMap, tap, throwError } from 'rxjs';
+import { AsyncSubject, BehaviorSubject, catchError, combineLatest, filter, map, Observable, of, ReplaySubject, share, shareReplay, startWith, switchMap, tap, throwError } from 'rxjs';
 import { AttendanceSession } from 'src/app/models/attendance-session.model';
 import { Student } from 'src/app/models/student.model';
 import { User } from 'src/app/models/user.model';
@@ -75,8 +75,8 @@ export class ShowStudentComponent implements OnInit {
   protected stateType = PageState;
   protected state = new BehaviorSubject<PageState>(PageState.STUDENT_LOADING);
 
-  protected student = new AsyncSubject<Student>()
-  protected registeredBy = new AsyncSubject<User>()
+  protected student = new ReplaySubject<Student>(1)
+  protected registeredBy = new ReplaySubject<User>(1)
 
   protected sessionsSubject = new ReplaySubject<AttendanceSession[]>(1);
 
@@ -109,7 +109,7 @@ export class ShowStudentComponent implements OnInit {
       studentRequest = of(null);
     }
 
-    const sharedStudentRequest = studentRequest.pipe(share());
+    const sharedStudentRequest = studentRequest.pipe(shareReplay(1));
     sharedStudentRequest.subscribe((student) => {
       if(student) {
         this.state.next(PageState.STUDENT_FOUND);
@@ -118,7 +118,7 @@ export class ShowStudentComponent implements OnInit {
       }
     })
     sharedStudentRequest.pipe(
-      filter((it): it is Student => !!it)
+      filter((it): it is Student => !!it),
     ).subscribe(this.student);
   }
 

--- a/attendance-web/src/app/components/students/show-student/show-student.component.ts
+++ b/attendance-web/src/app/components/students/show-student/show-student.component.ts
@@ -100,15 +100,11 @@ export class ShowStudentComponent implements OnInit {
     const studentId = parseInt(route.snapshot.paramMap.get('studentId') ?? 'NaN' );
     let studentRequest: Observable<Student|null>;
     if(studentId) {
-      studentRequest = studentService.getStudent(studentId, false).pipe(
-        catchError((error: HttpErrorResponse) => {
-          if(error.status == 404) {
-            return of(null);
-          }
-          throw error;
-        }),
-        errorService.interceptErrors()
-      );
+      studentRequest = studentService.getStudent(studentId).pipe(
+        // Stupid freaking javascript defining null and undefined as two different things!
+        // This converts the Observable<Student|undefined> => Observable<Student|null>
+        map(it => it ? it : null)
+      )
     } else {
       studentRequest = of(null);
     }

--- a/attendance-web/src/app/components/students/update-or-create-student/update-or-create-student.component.ts
+++ b/attendance-web/src/app/components/students/update-or-create-student/update-or-create-student.component.ts
@@ -1,9 +1,9 @@
-import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormGroup, FormControl, Validators, AsyncValidatorFn, FormGroupDirective } from '@angular/forms';
-import { ActivatedRoute, Router, UrlSegment } from '@angular/router';
-import { PendingUpdate, PendingUpdateType, StudentsService } from 'src/app/services/students.service';
+import { ActivatedRoute, Router } from '@angular/router';
+import { StudentsService } from 'src/app/services/students.service';
 import { Student } from 'src/app/models/student.model';
-import { AsyncSubject, BehaviorSubject, combineLatest, forkJoin, map, Observable, of, ReplaySubject, Subscription, take, tap } from 'rxjs';
+import { BehaviorSubject, forkJoin, map, Observable, of, ReplaySubject, Subscription, take } from 'rxjs';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
 enum ComponentState {
@@ -105,7 +105,7 @@ export class UpdateOrCreateStudentComponent implements OnInit, OnDestroy {
         if(student == null) {
           return;
         }
-        this.studentsService.updateStudent({id: student.id, name: studentName}).subscribe(
+        this.studentsService.updateStudent(student.id, {name: studentName}).subscribe(
           (student: Student) => {
             this.snackBar.open("Student " + student.name + " updated!", '', {
               duration: 4000
@@ -129,24 +129,15 @@ export class UpdateOrCreateStudentComponent implements OnInit, OnDestroy {
   }
 
   doDelete(student: Student) {
-    let pendingDelete = new PendingUpdate(student, PendingUpdateType.DELETE,
-      (update) => {
-        return this.studentsService.deleteStudent(student.id).pipe(map(it => void 0));
-      }
-    );
-
-    const updateId = this.studentsService.addPendingUpdate(pendingDelete);
+    this.studentsService.deleteStudent(student.id).subscribe();
 
     const snackBarRef = this.snackBar.open("Student " + student.name + " deleted!", 'Undo', {
       duration: 4000
     });
 
-    const deletionExecutor = snackBarRef.afterDismissed().subscribe(() => {
-      this.studentsService.commitPendingUpdate(updateId);
-    });
-
     snackBarRef.onAction().subscribe(() => {
-      this.studentsService.clearPendingUpdate(updateId);
+      // TODO
+      console.warn("Not yet implemented!");
     });
 
     this.router.navigate(['/', 'students']);

--- a/attendance-web/src/app/services/attendance.service.ts
+++ b/attendance-web/src/app/services/attendance.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http'
+import { HttpClient, HttpParams, HttpResponse } from '@angular/common/http'
 import { environment } from 'src/environments/environment';
 
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 
 import { AttendanceEvent, AttendanceEventType } from 'src/app/models/attendance-event.model';
 import { AttendanceSession } from '../models/attendance-session.model';
@@ -21,6 +21,12 @@ export class AttendanceService {
       'student_id': studentId,
       'type': eventType
     });
+  }
+
+  deleteEvent(eventId: number): Observable<boolean> {
+    return this.httpClient.delete<HttpResponse<any>>(environment.apiRoot + '/attendance/events/' + eventId, {
+      observe: 'response'
+    }).pipe(map(response => response.status == 200));
   }
 
   getEvents(options: {

--- a/attendance-web/src/app/services/poll.service.ts
+++ b/attendance-web/src/app/services/poll.service.ts
@@ -1,0 +1,39 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { DateTime } from 'luxon';
+import { Student } from '../models/student.model';
+import { MeetingEvent } from '../models/meeting-event.model';
+import { Observable, interval, switchMap } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+export interface PollResponse {
+  updated_students: Student[],
+  meeting_events: MeetingEvent[]
+};
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PollService {
+
+  constructor(private httpClient: HttpClient) { }
+
+  private getUpdates(options: {since: DateTime, until?: DateTime}): Observable<PollResponse> {
+    let params = new HttpParams();
+    params = params.set('since', Math.floor(options.since.toMillis() / 1000));
+    if(options.until) {
+      params = params.set('until', Math.floor(options.until.toMillis() / 1000));
+    }
+
+    return this.httpClient.get<PollResponse>(environment.apiRoot + '/poll', {params});
+  }
+
+  public getPollingObservable(): Observable<PollResponse> {
+    return interval(environment.pollInterval).pipe(
+      switchMap(() => {
+        const since = DateTime.now().minus({milliseconds: (1000 + environment.pollInterval)});
+        return this.getUpdates({since});
+      })
+    );
+  }
+}

--- a/attendance-web/src/app/services/students.service.spec.ts
+++ b/attendance-web/src/app/services/students.service.spec.ts
@@ -6,15 +6,10 @@ import { Student } from "../models/student.model";
 import { StudentsService } from "./students.service";
 
 describe('StudentsService', () => {
-    let httpClientSpy: jasmine.SpyObj<HttpClient>;
-    let studentsService: StudentsService;
-
-    beforeEach(() => {
-        httpClientSpy = jasmine.createSpyObj('HttpClient', ['get']);
-        studentsService = new StudentsService(httpClientSpy);
-    })
-
     it('should return all students', (done: DoneFn) => {
+        let httpClientSpy: jasmine.SpyObj<HttpClient> = jasmine.createSpyObj('HttpClient', ['get']);
+        let studentsService: StudentsService;
+
         const now = DateTime.now();
         const expectedStudents: Array<Student> = [
             {
@@ -42,6 +37,7 @@ describe('StudentsService', () => {
         ];
 
         httpClientSpy.get.and.returnValue(of(expectedStudents));
+        studentsService = new StudentsService(httpClientSpy);
 
         studentsService.getAllStudents().subscribe({
             next: students => {

--- a/attendance-web/src/app/services/students.service.ts
+++ b/attendance-web/src/app/services/students.service.ts
@@ -39,7 +39,7 @@ export class StudentsService {
       .subscribe(student => this.updateStudentsInCache([student]));
   }
 
-  private updateStudentsInCache(new_students: Student[]) {
+  public updateStudentsInCache(new_students: Student[]) {
     this.cachedStudents.pipe(
       take(1),
       map(student_map => {


### PR DESCRIPTION
Attendance events are now soft-deleted on the server.

Attendance events are now immediately propagated to the backend, and undo operations are actually soft-deleting the recently created attendance event.

Polling now occurs using the dedicated /api/poll route instead of the two individual /attendance/events and /meetings.

resolves #40, resolves #49