### PR TITLE
Dynamic roles

### DIFF
--- a/attendance-api/app/Http/Controllers/AttendanceEventController.php
+++ b/attendance-api/app/Http/Controllers/AttendanceEventController.php
@@ -17,6 +17,10 @@ use Illuminate\Support\Facades\Gate;
 
 class AttendanceEventController extends Controller
 {
+    public function __construct() {
+        $this->middleware('can:list attendance events')->only(['index', 'show']);
+    }
+
     public function index(Request $request) {
         $request->validate([
             'student_id' => 'exists:students,id',

--- a/attendance-api/app/Http/Controllers/StudentController.php
+++ b/attendance-api/app/Http/Controllers/StudentController.php
@@ -18,6 +18,7 @@ use InvalidArgumentException;
 class StudentController extends Controller
 {
     public function __construct() {
+        $this->middleware('can:list students')->only(['index', 'show']);
         $this->middleware('can:add students')->only('store');
         $this->middleware('can:modify students')->only('update');
         $this->middleware('can:remove students')->only('destroy');

--- a/attendance-api/database/seeders/RolesSeeder.php
+++ b/attendance-api/database/seeders/RolesSeeder.php
@@ -21,6 +21,7 @@ class RolesSeeder extends Seeder
 
         app()[\Spatie\Permission\PermissionRegistrar::class]->forgetCachedPermissions();
 
+        Permission::create(['name' => 'list students']);
         Permission::create(['name' => 'add students']);
         Permission::create(['name' => 'modify students']);
         Permission::create(['name' => 'remove students']);
@@ -44,6 +45,7 @@ class RolesSeeder extends Seeder
 
         Role::create(['name' => 'mentor'])
             ->givePermissionTo([
+                'list students',
                 'add students',
                 'view student images',
                 'modify students',
@@ -64,6 +66,7 @@ class RolesSeeder extends Seeder
 
         Role::create(['name' => 'student-lead'])
             ->givePermissionTo([
+                'list students',
                 'student check in',
                 'view student images',
                 'undo attendance event',

--- a/attendance-api/database/seeders/RolesSeeder.php
+++ b/attendance-api/database/seeders/RolesSeeder.php
@@ -80,6 +80,17 @@ class RolesSeeder extends Seeder
                 'view stats'
             ]);
 
+        Role::create(['name' => 'read-only'])
+            ->givePermissionTo([
+                'list students',
+                'list attendance events',
+                'view student images',
+                'list users',
+                'list roles',
+                'list meeting events',
+                'view stats'
+            ]);
+
         // Here I hard-code the initial admin user (who will then add the rest of the admins)
         // It'd probably be best to get this from the app config or the .env environment
         if(config('app.debug', false)) {

--- a/attendance-api/database/seeders/RolesSeeder.php
+++ b/attendance-api/database/seeders/RolesSeeder.php
@@ -28,6 +28,7 @@ class RolesSeeder extends Seeder
         Permission::create(['name' => 'view student images']);
         Permission::create(['name' => 'modify student images']);
 
+        Permission::create(['name' => 'list attendance events']);
         Permission::create(['name' => 'student check in']);
         Permission::create(['name' => 'student check out']);
         Permission::create(['name' => 'undo attendance event']);
@@ -51,6 +52,7 @@ class RolesSeeder extends Seeder
                 'modify students',
                 'modify student images',
                 'remove students',
+                'list attendance events',
                 'student check in',
                 'student check out',
                 'undo attendance event',
@@ -67,6 +69,7 @@ class RolesSeeder extends Seeder
         Role::create(['name' => 'student-lead'])
             ->givePermissionTo([
                 'list students',
+                'list attendance events',
                 'student check in',
                 'view student images',
                 'undo attendance event',

--- a/attendance-api/routes/api.php
+++ b/attendance-api/routes/api.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\ReportController;
 use App\Http\Controllers\PollController;
 use App\Http\Controllers\StudentProfileImageController;
 use Spatie\Permission\Models\Role;
+use Spatie\Permission\Models\Permission;
 
 /*
 |--------------------------------------------------------------------------
@@ -47,14 +48,14 @@ Route::middleware('auth:sanctum')->group(function () {
         'index', 'show', 'update'
     ]);
 
-    Route::middleware('can:list roles')->get('roles', function() {
-        return Role::all()->pluck('name');
-    });
-
     Route::get('reports/list-meetings', [ReportController::class, 'listMeetings']);
     Route::get('reports/meeting-attendance', [ReportController::class, 'meetingAttendance']);
     Route::get('poll', [PollController::class, 'poll']);
 
+    Route::get('roles', fn () => collect([
+        "roles" => Role::all()->map(fn ($role) => ['name'=>$role->name, 'permissions'=>$role->permissions->pluck("name")]),
+        "permissions" => Permission::all()->pluck("name")
+    ]));
 });
 
 Route::get('info', fn () => ['git_hash' => config('app.git_hash')]);

--- a/attendance-web/src/app/app-routing.module.ts
+++ b/attendance-web/src/app/app-routing.module.ts
@@ -63,9 +63,9 @@ const routes: Routes = [
     canActivate: [MustBeLoggedInGuard],
     children: [
       { path: 'check-in', component: AddAttendanceEventListComponent,
-        canActivate: [MustHavePermissionGuard], data: { permissions: [ 'student check in' ]}},
+        canActivate: [MustHavePermissionGuard], data: { permissions: [ 'list attendance events' ]}},
       { path: 'check-out', component: AddAttendanceEventListComponent,
-        canActivate: [MustHavePermissionGuard], data: { permissions: [ 'student check in' ]}}
+        canActivate: [MustHavePermissionGuard], data: { permissions: [ 'list attendance events' ]}}
     ]
   },
   { path: 'error', component: ErrorComponent },

--- a/attendance-web/src/app/app-routing.module.ts
+++ b/attendance-web/src/app/app-routing.module.ts
@@ -23,7 +23,7 @@ import { MeetingAttendanceReportComponent } from './components/reports/meeting-a
 const routes: Routes = [
   { path: 'students', component: StudentsComponent,
     canActivate: [MustBeLoggedInGuard, MustHavePermissionGuard],
-    data: { permissions: ['view student images']},
+    data: { permissions: ['list students', 'view student images']},
     children: [
       {path: '', redirectTo: 'list', pathMatch: 'full'},
       {path: 'detail/:studentId', component: ShowStudentComponent},
@@ -42,7 +42,7 @@ const routes: Routes = [
   },
   { path: 'reports', component: ReportsComponent,
     canActivate: [MustBeLoggedInGuard, MustHavePermissionGuard],
-    data: { permissions: ['view stats'] },
+    data: { permissions: ['list students', 'view stats'] },
     children: [
       { path: '', redirectTo: 'meetings', pathMatch: 'full' },
       { path: 'meetings', component: MeetingsReportComponent },

--- a/attendance-web/src/app/app-routing.module.ts
+++ b/attendance-web/src/app/app-routing.module.ts
@@ -6,7 +6,7 @@ import { LoginComponent } from './components/login/login.component';
 import { UpdateOrCreateStudentComponent } from './components/students/update-or-create-student/update-or-create-student.component';
 import { MustBeLoggedInGuard } from './guards/must-be-logged-in.guard';
 import { MustNotBeLoggedInGuard } from './guards/must-not-be-logged-in.guard';
-import { MustHaveRoleGuard } from './guards/must-have-role.guard';
+import { MustHavePermissionGuard } from './guards/must-have-role.guard';
 import { StudentsComponent } from './components/students/students.component';
 import { ListStudentsComponent } from './components/students/list-students/list-students.component';
 import { ImportStudentsComponent } from './components/students/import-students/import-students.component';
@@ -22,24 +22,27 @@ import { MeetingAttendanceReportComponent } from './components/reports/meeting-a
 
 const routes: Routes = [
   { path: 'students', component: StudentsComponent,
-    canActivate: [MustBeLoggedInGuard, MustHaveRoleGuard],
-    data: { roleOptions: ['mentor', 'student-lead']},
+    canActivate: [MustBeLoggedInGuard, MustHavePermissionGuard],
+    data: { permissions: ['view student images']},
     children: [
       {path: '', redirectTo: 'list', pathMatch: 'full'},
       {path: 'detail/:studentId', component: ShowStudentComponent},
       { path: 'edit/:studentId', component: UpdateOrCreateStudentComponent,
-        canActivate: [MustHaveRoleGuard],
-        data: { roleOptions: ['mentor'] }},
+        canActivate: [MustHavePermissionGuard],
+        data: { permissions: ['modify students', 'modify student images', 'remove students'] }},
       {path: 'list', component: ListStudentsComponent},
       {path: 'add', component: UpdateOrCreateStudentComponent,
-        canActivate: [MustHaveRoleGuard],
-        data: { roleOptions: ['mentor'] }},
-      {path: 'import', component: ImportStudentsComponent}
+        canActivate: [MustHavePermissionGuard],
+        data: { permissions: ['add students', 'modify student images'] }},
+      {path: 'import', component: ImportStudentsComponent,
+        canActivate: [MustHavePermissionGuard],
+        data: { permissions: ['add students', 'modify student images'] }
+      }
     ]
   },
   { path: 'reports', component: ReportsComponent,
-    canActivate: [MustBeLoggedInGuard, MustHaveRoleGuard],
-    data: { roleOptions: ['mentor', 'student-lead']},
+    canActivate: [MustBeLoggedInGuard, MustHavePermissionGuard],
+    data: { permissions: ['view stats'] },
     children: [
       { path: '', redirectTo: 'meetings', pathMatch: 'full' },
       { path: 'meetings', component: MeetingsReportComponent },
@@ -50,19 +53,19 @@ const routes: Routes = [
     ]
   },
   { path: 'meetings', component: MeetingEventsComponent,
-    canActivate: [MustBeLoggedInGuard, MustHaveRoleGuard],
-    data: { roleOptions: ['mentor', 'student-lead']}
+    canActivate: [MustBeLoggedInGuard, MustHavePermissionGuard],
+    data: { permissions: ['list meeting events', 'add meeting events']}
   },
-  { path: 'users', component: ElevateUsersComponent, canActivate: [MustBeLoggedInGuard, MustHaveRoleGuard],
-    data: { roleOptions: ['mentor'] }},
+  { path: 'users', component: ElevateUsersComponent, canActivate: [MustBeLoggedInGuard, MustHavePermissionGuard],
+    data: { permissions: ['elevate users'] }},
   { path: 'login', component: LoginComponent, canActivate: [MustNotBeLoggedInGuard] },
   { path: '', component: HomeComponent,
     canActivate: [MustBeLoggedInGuard],
     children: [
       { path: 'check-in', component: AddAttendanceEventListComponent,
-        canActivate: [MustHaveRoleGuard], data: { roleOptions: [ 'mentor', 'student-lead' ]}},
+        canActivate: [MustHavePermissionGuard], data: { permissions: [ 'student check in' ]}},
       { path: 'check-out', component: AddAttendanceEventListComponent,
-        canActivate: [MustHaveRoleGuard], data: { roleOptions: [ 'mentor', 'student-lead' ]}}
+        canActivate: [MustHavePermissionGuard], data: { permissions: [ 'student check in' ]}}
     ]
   },
   { path: 'error', component: ErrorComponent },

--- a/attendance-web/src/app/app.component.html
+++ b/attendance-web/src/app/app.component.html
@@ -20,25 +20,25 @@
                         <p class="nav-label">Home</p>
                     </a>
                 </mat-list-item>
-                <mat-list-item *ngIf="authService.checkHasAnyRole(['mentor', 'student-lead']) | async" >
+                <mat-list-item *ngIf="permissionsService.checkPermissions(['list meeting events', 'add meeting events']) | async" >
                     <a class="nav-list-item" (click)="sidenav.close()" routerLink="/meetings">
                         <mat-icon class="nav-icon">date_range</mat-icon>
                         <p class="nav-label">Meetings</p>
                     </a>
                 </mat-list-item>
-                <mat-list-item *ngIf="authService.checkHasAnyRole(['mentor', 'student-lead']) | async">
+                <mat-list-item *ngIf="permissionsService.checkPermissions(['view stats']) | async">
                     <a class="nav-list-item" (click)="sidenav.close()" routerLink="/reports">
                         <mat-icon class="nav-icon">description</mat-icon>
                         <p class="nav-label">Reports</p>
                     </a>
                 </mat-list-item>
-                <mat-list-item *ngIf="authService.checkHasAnyRole(['mentor', 'student-lead']) | async" >
+                <mat-list-item *ngIf="permissionsService.checkPermissions(['view student images']) | async" >
                     <a class="nav-list-item" (click)="sidenav.close()" routerLink="/students">
                         <mat-icon class="nav-icon">groups</mat-icon>
                         <p class="nav-label">Students</p>
                     </a>
                 </mat-list-item>
-                <mat-list-item *ngIf="authService.checkHasAnyRole(['mentor']) | async">
+                <mat-list-item *ngIf="permissionsService.checkPermissions(['elevate users']) | async">
                     <a class="nav-list-item" (click)="sidenav.close()" routerLink="/users">
                         <mat-icon class="nav-icon">person</mat-icon>
                         <p class="nav-label">Users</p>

--- a/attendance-web/src/app/app.component.html
+++ b/attendance-web/src/app/app.component.html
@@ -26,13 +26,13 @@
                         <p class="nav-label">Meetings</p>
                     </a>
                 </mat-list-item>
-                <mat-list-item *ngIf="permissionsService.checkPermissions(['view stats']) | async">
+                <mat-list-item *ngIf="permissionsService.checkPermissions(['list students', 'view stats']) | async">
                     <a class="nav-list-item" (click)="sidenav.close()" routerLink="/reports">
                         <mat-icon class="nav-icon">description</mat-icon>
                         <p class="nav-label">Reports</p>
                     </a>
                 </mat-list-item>
-                <mat-list-item *ngIf="permissionsService.checkPermissions(['view student images']) | async" >
+                <mat-list-item *ngIf="permissionsService.checkPermissions(['list students', 'view student images']) | async" >
                     <a class="nav-list-item" (click)="sidenav.close()" routerLink="/students">
                         <mat-icon class="nav-icon">groups</mat-icon>
                         <p class="nav-label">Students</p>

--- a/attendance-web/src/app/app.component.html
+++ b/attendance-web/src/app/app.component.html
@@ -5,7 +5,7 @@
                 <button mat-icon-button *ngIf="authService.checkLoggedIn() | async" aria-label="Button to open the navigation menu" (click)="sidenav.toggle()">
                     <mat-icon>menu</mat-icon>
                 </button>
-                <a routerLink="/check-in" id="title">Attendance Manager</a>
+                <a routerLink="/" id="title">Attendance Manager</a>
             </div>
             <span id="userName" *ngIf="getFirstName() | async as name">Welcome, {{name}}</span>
             </div>
@@ -15,7 +15,7 @@
             <div id="sidebar-container">
             <mat-action-list>
                 <mat-list-item>
-                    <a class="nav-list-item" (click)="sidenav.close()" routerLink="/check-in">
+                    <a class="nav-list-item" (click)="sidenav.close()" routerLink="/">
                         <mat-icon class="nav-icon">home</mat-icon>
                         <p class="nav-label">Home</p>
                     </a>

--- a/attendance-web/src/app/app.component.ts
+++ b/attendance-web/src/app/app.component.ts
@@ -6,6 +6,7 @@ import { AuthService } from './services/auth.service';
 import { StudentsService } from './services/students.service';
 import { HttpClient } from '@angular/common/http';
 import { ServerInfoService } from './services/server-info.service';
+import { PermissionsService } from './services/permissions.service';
 
 @Component({
     selector: 'app-root',
@@ -25,7 +26,8 @@ export class AppComponent {
     protected authService: AuthService,
     protected studentsService: StudentsService,
     protected snackbar: MatSnackBar,
-    private serverInfo: ServerInfoService
+    protected permissionsService: PermissionsService,
+    serverInfo: ServerInfoService,
   ) {
     this.server_hash = serverInfo.getServerHash();
   }

--- a/attendance-web/src/app/components/elevate-users/user/user.component.ts
+++ b/attendance-web/src/app/components/elevate-users/user/user.component.ts
@@ -5,6 +5,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { BehaviorSubject, map } from 'rxjs';
 import { User } from 'src/app/models/user.model';
 import { AuthService } from 'src/app/services/auth.service';
+import { PermissionsService } from 'src/app/services/permissions.service';
 import { UsersService } from 'src/app/services/users.service';
 
 @Component({
@@ -18,12 +19,13 @@ export class UserComponent implements OnInit {
 
   protected selectedRole! : FormControl<string|null>
 
-  protected roles = this.usersService.getAllRoles().pipe(map(roles => roles.concat(['none'])));
+  protected roles = this.permissionsService.getAllRoles().pipe(map(roles => roles.map(role => role.name).concat(['none'])));
   protected loggedInUser = this.authService.getUser();
 
   constructor(
     private authService: AuthService,
     private usersService: UsersService,
+    private permissionsService: PermissionsService,
     private snackbar: MatSnackBar
   ) { }
 

--- a/attendance-web/src/app/components/home/home.component.html
+++ b/attendance-web/src/app/components/home/home.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="authService.checkHasAnyRole(allowedRoles) | async; else notMentorHome">
+<ng-container *ngIf="shouldShowNavBar() | async; else notMentorHome">
     <nav mat-tab-nav-bar [tabPanel]="eventOptionsTabPanel" mat-stretch-tabs="false" mat-align-tabs="start" id="navTabs">
         <a mat-tab-link *ngFor="let tab of tabs"
             [routerLink]="tab.path"

--- a/attendance-web/src/app/components/home/home.component.html
+++ b/attendance-web/src/app/components/home/home.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="shouldShowNavBar() | async; else notMentorHome">
+<ng-container *ngIf="shouldShowAttendanceEvents() | async; else notMentorHome">
     <nav mat-tab-nav-bar [tabPanel]="eventOptionsTabPanel" mat-stretch-tabs="false" mat-align-tabs="start" id="navTabs">
         <a mat-tab-link *ngFor="let tab of tabs"
             [routerLink]="tab.path"

--- a/attendance-web/src/app/components/home/home.component.ts
+++ b/attendance-web/src/app/components/home/home.component.ts
@@ -1,6 +1,9 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { map, Observable, take } from 'rxjs';
 import { AuthService } from 'src/app/services/auth.service';
+import { PermissionsService } from 'src/app/services/permissions.service';
+import { UsersService } from 'src/app/services/users.service';
 
 @Component({
     selector: 'app-home',
@@ -19,16 +22,25 @@ export class HomeComponent implements OnInit {
     }
   ];
 
-  allowedRoles = ['mentor', 'student-lead'];
+  requiredPermission = 'student check in';
 
   constructor(
     protected authService: AuthService,
+    protected permissionsService: PermissionsService,
     route: ActivatedRoute,
     router: Router
   ) {
-    if(route.snapshot.url.length == 0 && authService.checkHasAnyRole(this.allowedRoles)) {
-      router.navigate(['check-in']);
+    if(route.snapshot.url.length == 0) {
+      permissionsService.checkPermissions([this.requiredPermission]).subscribe(authorized => {
+        if(authorized) {
+          router.navigate(['check-in']);
+        }
+      })
     }
+  }
+
+  protected shouldShowNavBar(): Observable<boolean> {
+    return this.authService.getUser().pipe(take(1), map(user => user !== null && user.role_names.length > 0));
   }
 
   ngOnInit(): void {

--- a/attendance-web/src/app/components/home/home.component.ts
+++ b/attendance-web/src/app/components/home/home.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
-import { map, Observable, take } from 'rxjs';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, Router, RouterEvent } from '@angular/router';
+import { filter, map, Observable, Subscription, take } from 'rxjs';
 import { AuthService } from 'src/app/services/auth.service';
 import { PermissionsService } from 'src/app/services/permissions.service';
 import { UsersService } from 'src/app/services/users.service';
@@ -11,7 +11,7 @@ import { UsersService } from 'src/app/services/users.service';
     styleUrls: ['./home.component.scss'],
     standalone: false
 })
-export class HomeComponent implements OnInit {
+export class HomeComponent implements OnInit, OnDestroy {
   tabs = [
     {
       path: './check-in',
@@ -22,28 +22,45 @@ export class HomeComponent implements OnInit {
     }
   ];
 
-  requiredPermission = 'student check in';
+  requiredPermission = 'list attendance events';
+
+  routersub!: Subscription;
 
   constructor(
-    protected authService: AuthService,
     protected permissionsService: PermissionsService,
-    route: ActivatedRoute,
-    router: Router
+    protected route: ActivatedRoute,
+    protected router: Router
   ) {
-    if(route.snapshot.url.length == 0) {
-      permissionsService.checkPermissions([this.requiredPermission]).subscribe(authorized => {
-        if(authorized) {
-          router.navigate(['check-in']);
-        }
-      })
-    }
   }
 
-  protected shouldShowNavBar(): Observable<boolean> {
-    return this.authService.getUser().pipe(take(1), map(user => user !== null && user.role_names.length > 0));
+  protected shouldShowAttendanceEvents(): Observable<boolean> {
+    return this.permissionsService.checkPermissions(['list attendance events']);
   }
 
   ngOnInit(): void {
+    if(this.route.snapshot.url.length == 0) {
+      this.permissionsService.checkPermissions([this.requiredPermission]).subscribe(authorized => {
+        if(authorized) {
+          this.router.navigate(['check-in']);
+        }
+      })
+    }
+
+    this.routersub = this.router.events.pipe(
+      filter(e => e instanceof RouterEvent)
+    ).subscribe(event => {
+      if(event.url == '/') {
+        this.permissionsService.checkPermissions([this.requiredPermission]).subscribe(authorized => {
+          if(authorized) {
+            this.router.navigate(['check-in']);
+          }
+        })
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.routersub.unsubscribe();
   }
 
 }

--- a/attendance-web/src/app/components/meeting-events/meeting-events.component.html
+++ b/attendance-web/src/app/components/meeting-events/meeting-events.component.html
@@ -3,7 +3,7 @@
 <h2>Actions</h2>
 <mat-card>
     <mat-card-content id="actions">
-    <button mat-raised-button color="primary" class="meetingAction" [disabled]="notAllowedToEndMeetings()|async" (click)="registerEndOfMeeting()">End Meeting</button>
+    <button mat-raised-button color="primary" class="meetingAction" (click)="registerEndOfMeeting()">End Meeting</button>
     </mat-card-content>
 </mat-card>
 

--- a/attendance-web/src/app/components/meeting-events/meeting-events.component.ts
+++ b/attendance-web/src/app/components/meeting-events/meeting-events.component.ts
@@ -10,6 +10,7 @@ import { MeetingsService } from 'src/app/services/meetings.service';
 import { UsersService } from 'src/app/services/users.service';
 import { PaginatedDataSource } from 'src/app/utils/PaginatedDataSource';
 import { ConfirmDialogComponent } from '../reuse/confirm-dialog/confirm-dialog.component';
+import { PermissionsService } from 'src/app/services/permissions.service';
 
 interface RichMeetingEvent {
   event: MeetingEvent,
@@ -38,7 +39,7 @@ export class MeetingEventsComponent implements OnInit {
 
   constructor(
     private meetingsService: MeetingsService,
-    private authService: AuthService,
+    private permissionsService: PermissionsService,
     private usersService: UsersService,
     private dialog: MatDialog,
   ) {
@@ -58,9 +59,11 @@ export class MeetingEventsComponent implements OnInit {
       this.loadingEvents = false;
     });
 
-    authService.checkHasAnyRole(['mentor']).subscribe(isMentor => {
-      this.eventColumns = this.eventColumns.concat('removeAction');
-    })
+    permissionsService.checkPermissions(['remove meeting events']).subscribe(isMentor => {
+      if(isMentor) {
+        this.eventColumns = this.eventColumns.concat('removeAction');
+      }
+    });
   }
 
   ngOnInit(): void {
@@ -131,11 +134,5 @@ export class MeetingEventsComponent implements OnInit {
         ).subscribe(events => this.events.next(events));
       });
     });
-  }
-
-  notAllowedToEndMeetings(): Observable<boolean> {
-    // At the moment this feature isn't doing anything, but if we should decide that only
-    // mentors may mark end-of-meeting events, then this makes the change easy.
-    return this.authService.checkHasAnyRole(['mentor', 'student-lead']).pipe(map(it => !it));
   }
 }

--- a/attendance-web/src/app/components/reports/event-log/event-log.component.ts
+++ b/attendance-web/src/app/components/reports/event-log/event-log.component.ts
@@ -14,6 +14,7 @@ import { UsersService } from 'src/app/services/users.service';
 import { PaginatedDataSource } from 'src/app/utils/PaginatedDataSource';
 import { ConfirmDialogComponent } from 'src/app/components/reuse/confirm-dialog/confirm-dialog.component';
 import { AuthService } from 'src/app/services/auth.service';
+import { PermissionsService } from 'src/app/services/permissions.service';
 
 interface EventLogEvent {
   eventId: string,
@@ -64,7 +65,7 @@ export class EventLogComponent implements OnInit {
     private studentsService: StudentsService,
     private usersService: UsersService,
     private meetingsService: MeetingsService,
-    private authService: AuthService
+    private permissionsService: PermissionsService
   ) {
     combineLatest({
       dates: this.listOptions.controls['until'].valueChanges.pipe(
@@ -98,11 +99,8 @@ export class EventLogComponent implements OnInit {
       }
     })
 
-    authService.checkHasAnyRole(['mentor']).subscribe((isMentor) => {
-      this.showActions.next(isMentor);
-    });
-
-
+    permissionsService.checkPermissions(['delete attendance event']).subscribe(
+      canDelete => this.showActions.next(canDelete));
   }
 
   ngOnInit(): void {

--- a/attendance-web/src/app/components/students/import-students/import-students.component.ts
+++ b/attendance-web/src/app/components/students/import-students/import-students.component.ts
@@ -162,7 +162,7 @@ export class ImportStudentsComponent implements OnInit {
           this.snackBar.open('Registered ' + items.length + ' new students', '', {
             duration: 4000
           });
-          this.studentsService.invalidateCache();
+          this.studentsService.refreshCache();
           this.router.navigate(['/', 'students', 'list'])
         })
       )), // 10, 20, 30, ..., 100

--- a/attendance-web/src/app/components/students/list-students/list-students.component.html
+++ b/attendance-web/src/app/components/students/list-students/list-students.component.html
@@ -8,7 +8,7 @@
 <mat-menu #filterMenu="matMenu">
     <div id="filterMenuContainer">
         <mat-slide-toggle [formControl]="showDeleted">Include deleted</mat-slide-toggle>
-        <mat-slide-toggle [formControl]="showEditControl" *ngIf="authService.checkHasAnyRole(['mentor']) | async">Edit</mat-slide-toggle>
+        <mat-slide-toggle [formControl]="showEditControl" *ngIf="shouldShowEditMenu() | async">Edit</mat-slide-toggle>
     </div>
 </mat-menu>
 

--- a/attendance-web/src/app/components/students/list-students/list-students.component.ts
+++ b/attendance-web/src/app/components/students/list-students/list-students.component.ts
@@ -8,6 +8,7 @@ import { Student, StudentList, compareStudents } from 'src/app/models/student.mo
 import { AuthService } from 'src/app/services/auth.service';
 import { StudentsService } from 'src/app/services/students.service';
 import { ConfirmDialogComponent } from 'src/app/components/reuse/confirm-dialog/confirm-dialog.component';
+import { PermissionsService } from 'src/app/services/permissions.service';
 
 @Component({
     selector: 'app-list-students',
@@ -49,6 +50,7 @@ export class ListStudentsComponent implements OnInit, OnDestroy {
     public authService: AuthService,
     private router: Router,
     private dialog: MatDialog,
+    private permissionsService: PermissionsService
   ) {
     this.everyCheckedStudentNotDeleted = this.checkedStudents.pipe(
       map(students => students.find(it => it.deleted_at != undefined) == undefined)
@@ -231,6 +233,10 @@ export class ListStudentsComponent implements OnInit, OnDestroy {
     } else {
       this.router.navigate(['students', 'detail', student.id]);
     }
+  }
+
+  shouldShowEditMenu(): Observable<boolean> {
+    return this.permissionsService.checkPermissions(['modify students', 'modify student images', 'remove students']);
   }
 
 }

--- a/attendance-web/src/app/components/students/show-student/show-student.component.ts
+++ b/attendance-web/src/app/components/students/show-student/show-student.component.ts
@@ -11,6 +11,7 @@ import { User } from 'src/app/models/user.model';
 import { AttendanceService } from 'src/app/services/attendance.service';
 import { AuthService } from 'src/app/services/auth.service';
 import { ErrorService } from 'src/app/services/error.service';
+import { PermissionsService } from 'src/app/services/permissions.service';
 import { ReportsService } from 'src/app/services/reports.service';
 import { StudentsService } from 'src/app/services/students.service';
 import { UsersService } from 'src/app/services/users.service';
@@ -105,7 +106,7 @@ export class ShowStudentComponent implements OnInit, OnDestroy {
     private usersService: UsersService,
     private attendanceService: AttendanceService,
     private errorService: ErrorService,
-    private authService: AuthService,
+    private permissionsService: PermissionsService,
     private reportsService: ReportsService
   ) {
     const studentId = parseInt(route.snapshot.paramMap.get('studentId') ?? 'NaN' );
@@ -183,7 +184,7 @@ export class ShowStudentComponent implements OnInit, OnDestroy {
   }
 
   canDelete(): Observable<boolean> {
-    return this.authService.checkHasAnyRole(["mentor"]);
+    return this.permissionsService.checkPermissions(['modify students', 'modify student images', 'remove students']);
   }
 
   getProfileImageSrc(student: Student): string {

--- a/attendance-web/src/app/components/students/update-or-create-student/update-or-create-student.component.ts
+++ b/attendance-web/src/app/components/students/update-or-create-student/update-or-create-student.component.ts
@@ -175,7 +175,7 @@ export class UpdateOrCreateStudentComponent implements OnInit, OnDestroy {
         name: studentName,
         graduation_year
       }).subscribe((student: Student) => {
-        this.studentsService.invalidateCache();
+        this.studentsService.refreshCache();
         this.mainForm.enable();
         this.mainForm.reset();
         formDirective.resetForm();

--- a/attendance-web/src/app/guards/must-have-role.guard.ts
+++ b/attendance-web/src/app/guards/must-have-role.guard.ts
@@ -1,29 +1,29 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, CanActivateChild, RouterStateSnapshot, UrlTree } from '@angular/router';
-import { Observable } from 'rxjs';
-import { AuthService } from '../services/auth.service';
+import { forkJoin, map, Observable, take } from 'rxjs';
+import { PermissionsService } from 'src/app/services/permissions.service';
 
 @Injectable({
   providedIn: 'root'
 })
-export class MustHaveRoleGuard implements CanActivate, CanActivateChild {
+export class MustHavePermissionGuard implements CanActivate, CanActivateChild {
 
-  constructor(private authService: AuthService) {}
+  constructor(private permissionsService: PermissionsService) {}
 
   canActivate(
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
-    return this.checkRoles(route);
+    return this.checkPermissions(route);
   }
   canActivateChild(
     childRoute: ActivatedRouteSnapshot,
     state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
-    return this.checkRoles(childRoute);
+    return this.checkPermissions(childRoute);
   }
 
-  private checkRoles(route: ActivatedRouteSnapshot) : Observable<boolean> {
-    let routeRoles = route.data['roleOptions'] as Array<string>;
-    return this.authService.checkHasAnyRole(routeRoles);
+  private checkPermissions(route: ActivatedRouteSnapshot) : Observable<boolean> {
+    let routePermissions = route.data['permissions'] as Array<string>;
+    return this.permissionsService.checkPermissions(routePermissions);
   }
 
 }

--- a/attendance-web/src/app/models/role.model.ts
+++ b/attendance-web/src/app/models/role.model.ts
@@ -1,0 +1,11 @@
+export type Permission = string;
+
+export interface Role {
+    name: string,
+    permissions: Permission[]
+};
+
+export interface RolesResponse {
+    roles: Role[],
+    permissions: Permission[]
+};

--- a/attendance-web/src/app/services/auth.service.ts
+++ b/attendance-web/src/app/services/auth.service.ts
@@ -52,17 +52,4 @@ export class AuthService {
     return this.cachedUser.pipe(map((user: User|null) => user != null));
   }
 
-  public checkHasAnyRole(roles: Array<string>): Observable<boolean> {
-    return this.cachedUser.pipe(
-      map((user: User|null) => {
-        if(user == null) {
-          return false;
-        }
-        return roles.reduce((previousValue, currentValue) =>
-          previousValue || user.role_names.includes(currentValue), false
-        );
-      })
-    );
-  }
-
 }

--- a/attendance-web/src/app/services/permissions.service.ts
+++ b/attendance-web/src/app/services/permissions.service.ts
@@ -1,0 +1,50 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { map, Observable, ReplaySubject, switchMap, take } from 'rxjs';
+import { environment } from 'src/environments/environment';
+import { Permission, Role, RolesResponse } from 'src/app/models/role.model';
+import { AuthService } from './auth.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PermissionsService {
+  private readonly roles = new ReplaySubject<Map<string, Role>>(1);
+  private readonly permissions = new ReplaySubject<Permission[]>(1);
+
+  constructor(private httpClient: HttpClient, private authService: AuthService) {
+    this.httpClient.get<RolesResponse>(environment.apiRoot + '/roles').subscribe(roles => {
+      this.roles.next(new Map(roles.roles.map(role => [role.name, role])));
+      this.permissions.next(roles.permissions);
+    });
+  }
+
+  public getAllRoles(): Observable<Role[]> {
+    return this.roles.pipe(map(roles => Array.from(roles.values())));
+  }
+
+  public checkPermissions(permissions: string[]): Observable<boolean> {
+    return this.authService.getUser().pipe(
+      take(1),
+      switchMap(user => this.roles.pipe(map(roles => {
+        if(user === null) {
+          return false;
+        }
+
+        return user.role_names.reduce((prev, role) => {
+          if(prev) {
+            return true;
+          }
+
+          if(!roles.has(role)) {
+            return false;
+          }
+
+          const role_permissions = roles.get(role)!!.permissions;
+          return permissions.reduce((prev, permission) => prev && role_permissions.includes(permission), true);
+        }, false);
+      }
+      ))
+    ));
+  }
+}

--- a/attendance-web/src/app/services/users.service.ts
+++ b/attendance-web/src/app/services/users.service.ts
@@ -9,11 +9,7 @@ import { User } from '../models/user.model';
 })
 export class UsersService {
 
-  private roles = new AsyncSubject<Array<string>>();
-
-  constructor(private httpClient: HttpClient) {
-    this.httpClient.get<Array<string>>(environment.apiRoot + '/roles').subscribe(this.roles);
-  }
+  constructor(private httpClient: HttpClient) {}
 
   public getAllUsers() : Observable<Array<User>> {
     return this.httpClient.get<Array<User>>(environment.apiRoot + '/users').pipe(share());
@@ -21,10 +17,6 @@ export class UsersService {
 
   public getUser(userId: number): Observable<User> {
     return this.httpClient.get<User>(environment.apiRoot + '/users/' + userId);
-  }
-
-  public getAllRoles() : Observable<Array<string>> {
-    return this.roles;
   }
 
   public syncUserRoles(userId: number, roles: Array<string>) : Observable<User> {


### PR DESCRIPTION
This patch removes the hardcoded role checks from the frontend, and replaces them with fine-grained permissions checks. The map of roles -> allowed permissions is retrieved from the server, then the user's role is looked-up to determine which actions the user is permitted to take.

This makes the configuration of new roles much easier, and permits us to add a new read-only role.

Resolves #95